### PR TITLE
Fix the dependencies and the LTS to allow building with the most recent base

### DIFF
--- a/hinterface.cabal
+++ b/hinterface.cabal
@@ -48,20 +48,20 @@ library
   build-depends:       QuickCheck >=2.11 && <2.14
                      , array >=0.5.2.0 && <0.6
                      , async >=2.2.1 && <2.3
-                     , base >= 4.9 && < 5
+                     , base >= 4.12 && < 5
                      , binary >=0.8.5.1 && <0.9
                      , bytestring >=0.10.8.2 && <0.11
                      , containers >=0.5.11.0 && <0.7
-                     , cryptonite == 0.25.*
+                     , cryptonite == 0.26.*
                      , deepseq >= 1.4 && <1.5
                      , exceptions >=0.10.0 && <0.11
                      , lifted-async >=0.10.0.2 && <0.11
                      , lifted-base >=0.2.3.12 && <0.3
-                     , memory >=0.14.16 && <0.15
+                     , memory == 0.15.*
                      , monad-control >=1.0.2.3 && <1.1
                      , monad-logger >=0.3.29 && <0.4
                      , mtl >=2.2.2 && <2.3
-                     , network >=2.6.3.6 && <2.9
+                     , network == 3.1.1.*
                      , random ==1.1.*
                      , resourcet >=1.2.1 && <1.3
                      , safe-exceptions >=0.1.7.0 && <0.2
@@ -79,7 +79,7 @@ test-suite hinterface-test
   main-is:             Spec.hs
   build-depends:       QuickCheck >=2.11.3 && <2.14
                      , async
-                     , base >= 4.9 && < 5
+                     , base >= 4.12 && < 5
                      , binary
                      , bytestring
                      , hinterface

--- a/src/Foreign/Erlang/ControlMessage.hs
+++ b/src/Foreign/Erlang/ControlMessage.hs
@@ -35,7 +35,7 @@ instance Binary ControlMessage where
         putWord8 pass_through
         put' controlMessage
       where
-        put' TICK = fail "Unreachable code"
+        put' TICK = error "Unreachable code"
 
         put' (LINK fromPid toPid) =
             put (MkExternalTerm (toTerm (linkTag, fromPid, toPid)))

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
 - .
 pvp-bounds: lower
 extra-deps: []
-resolver: lts-14.7
+resolver: lts-15.3


### PR DESCRIPTION
This PR also replaces the usage of `fail` with `error`, as well as moves the LTS to 15.3.